### PR TITLE
Fix: Remove duplicate auth middleware declarations

### DIFF
--- a/backend/routes/promotionRoutes.js
+++ b/backend/routes/promotionRoutes.js
@@ -247,21 +247,7 @@ router.delete('/:id', authenticateJWT, authorizePromotionOwnerOrAdmin, async (re
 });
 
 // Record a promotion click (Optionally authenticated)
-// We'll use a light middleware to make req.user available if token exists, but not fail if not.
-function gentleAuthenticateJWT(req, res, next) {
-  const authHeader = req.headers.authorization;
-  if (authHeader && authHeader.startsWith('Bearer ')) {
-    const token = authHeader.split(' ')[1];
-    jwt.verify(token, process.env.JWT_SECRET || 'your_jwt_secret', (err, user) => {
-      if (!err) {
-        req.user = user;
-      } // If error, just proceed without req.user
-      next();
-    });
-  } else {
-    next();
-  }
-}
+// Uses gentleAuthenticateJWT imported from ../middleware/auth
 router.post('/:id/click', gentleAuthenticateJWT, async (req, res) => {
   try {
     const promotion = await Promotion.findById(req.params.id);


### PR DESCRIPTION
This commit resolves SyntaxErrors caused by duplicate declarations of authentication/authorization middleware functions in route files after they were refactored into the shared `backend/middleware/auth.js`.

- Removed local definitions of `authorizeAdmin` and `authorizeSelfOrAdmin` in `backend/routes/userRoutes.js`.
- Removed local definition of `gentleAuthenticateJWT` in `backend/routes/promotionRoutes.js`.

These changes ensure the server uses the imported middleware versions and can start correctly.