### PR TITLE
feat: Add script to create demo admin and fix admin panel script loading

### DIFF
--- a/backend/scripts/create-demo-admin.js
+++ b/backend/scripts/create-demo-admin.js
@@ -1,0 +1,80 @@
+// create-demo-admin.js
+// This script creates a new demo admin user.
+
+require('dotenv').config({ path: require('path').resolve(__dirname, '../.env') });
+const mongoose = require('mongoose');
+const bcrypt = require('bcryptjs');
+const User = require('../models/User'); // Adjust path as necessary
+
+const DEMO_ADMIN_NAME = 'Demo Admin';
+const DEMO_ADMIN_EMAIL = 'admin@demo.com';
+const DEMO_ADMIN_PASSWORD = 'demoadmin123'; // This will be hashed
+
+async function createDemoAdminUser() {
+  if (!process.env.MONGO_URI) {
+    console.error('Error: MONGO_URI is not defined in your .env file.');
+    process.exit(1);
+  }
+
+  try {
+    console.log('Connecting to MongoDB...');
+    await mongoose.connect(process.env.MONGO_URI);
+    console.log('Successfully connected to MongoDB.');
+
+    console.log(`Checking if user with email "${DEMO_ADMIN_EMAIL}" already exists...`);
+    const existingUser = await User.findOne({ email: DEMO_ADMIN_EMAIL });
+
+    if (existingUser) {
+      console.warn(`Warning: User with email "${DEMO_ADMIN_EMAIL}" already exists.`);
+      console.log(`Name: ${existingUser.name}, Role: ${existingUser.role}`);
+      if (existingUser.role === 'admin') {
+        console.log('This user is already an admin. No action taken.');
+      } else {
+        console.log('This user is NOT an admin. If you want to make them an admin, run the make-admin.js script or update manually.');
+      }
+      await mongoose.disconnect();
+      process.exit(0); // Exit gracefully as user exists
+    }
+
+    console.log('User does not exist. Creating new demo admin user...');
+
+    console.log(`Hashing password for "${DEMO_ADMIN_EMAIL}"...`);
+    const hashedPassword = await bcrypt.hash(DEMO_ADMIN_PASSWORD, 10);
+    console.log('Password hashed.');
+
+    const newUser = new User({
+      name: DEMO_ADMIN_NAME,
+      email: DEMO_ADMIN_EMAIL,
+      password: hashedPassword,
+      role: 'admin',
+      // You can add other default fields if necessary, e.g., businessName
+    });
+
+    await newUser.save();
+    console.log('--------------------------------------------------');
+    console.log('🎉 Demo Admin User Created Successfully! 🎉');
+    console.log('--------------------------------------------------');
+    console.log(`Name: ${DEMO_ADMIN_NAME}`);
+    console.log(`Email: ${DEMO_ADMIN_EMAIL}`);
+    console.log(`Password: ${DEMO_ADMIN_PASSWORD} (Use this to log in)`);
+    console.log('Role: admin');
+    console.log('--------------------------------------------------');
+    console.log('You can now log in with these credentials.');
+    console.log('IMPORTANT: Consider changing the password after first login for security if this is a shared environment.');
+
+
+    await mongoose.disconnect();
+    console.log('Disconnected from MongoDB.');
+    process.exit(0);
+
+  } catch (error) {
+    console.error('An error occurred during demo admin creation:', error);
+    if (mongoose.connection.readyState === 1) { // 1 === connected
+      await mongoose.disconnect();
+      console.log('Disconnected from MongoDB due to error.');
+    }
+    process.exit(1);
+  }
+}
+
+createDemoAdminUser();

--- a/backend/scripts/make-admin.js
+++ b/backend/scripts/make-admin.js
@@ -1,0 +1,59 @@
+// make-admin.js
+// This script updates an existing user to have the 'admin' role.
+
+require('dotenv').config({ path: require('path').resolve(__dirname, '../.env') });
+const mongoose = require('mongoose');
+const User = require('../models/User'); // Adjust path as necessary
+
+const USER_EMAIL_TO_MAKE_ADMIN = 'drstoreslk@gmail.com';
+
+async function makeUserAdmin() {
+  if (!process.env.MONGO_URI) {
+    console.error('Error: MONGO_URI is not defined in your .env file.');
+    process.exit(1);
+  }
+
+  if (!USER_EMAIL_TO_MAKE_ADMIN) {
+    console.error('Error: No email address provided for the user to update.');
+    process.exit(1);
+  }
+
+  try {
+    console.log('Connecting to MongoDB...');
+    await mongoose.connect(process.env.MONGO_URI);
+    console.log('Successfully connected to MongoDB.');
+
+    console.log(`Searching for user with email: ${USER_EMAIL_TO_MAKE_ADMIN}...`);
+    const user = await User.findOne({ email: USER_EMAIL_TO_MAKE_ADMIN });
+
+    if (!user) {
+      console.error(`Error: User with email "${USER_EMAIL_TO_MAKE_ADMIN}" not found.`);
+      await mongoose.disconnect();
+      process.exit(1);
+    }
+
+    console.log(`User found: ${user.name} (Role: ${user.role})`);
+
+    if (user.role === 'admin') {
+      console.log(`User "${USER_EMAIL_TO_MAKE_ADMIN}" is already an admin.`);
+    } else {
+      user.role = 'admin';
+      await user.save();
+      console.log(`Successfully updated user "${USER_EMAIL_TO_MAKE_ADMIN}" to role "admin".`);
+    }
+
+    await mongoose.disconnect();
+    console.log('Disconnected from MongoDB.');
+    process.exit(0);
+
+  } catch (error) {
+    console.error('An error occurred:', error);
+    if (mongoose.connection.readyState === 1) { // 1 === connected
+      await mongoose.disconnect();
+      console.log('Disconnected from MongoDB due to error.');
+    }
+    process.exit(1);
+  }
+}
+
+makeUserAdmin();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -73,6 +73,16 @@
 		<script type="text/babel" src="/scripts/pages/ResetPasswordConfirmPage.js"></script>
 		<script type="text/babel" src="/scripts/pages/ResetPasswordPage.js"></script>
 		<script type="text/babel" src="/scripts/pages/DealPage.js"></script>
+
+		<!-- Admin Panel Sub-Components - Load these first -->
+		<script type="text/babel" src="/scripts/components/admin/UserManagement.js"></script>
+		<script type="text/babel" src="/scripts/components/admin/MerchantManagement.js"></script>
+		<script type="text/babel" src="/scripts/components/admin/PromotionManagement.js"></script>
+
+		<!-- Admin Dashboard Page - Load after its sub-components -->
+		<script type="text/babel" src="/scripts/pages/AdminDashboard.js"></script>
+
+		<!-- Main App - Load last or after all page/component scripts it might reference on window -->
 		<script type="text/babel" src="/scripts/App.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
- Adds `backend/scripts/create-demo-admin.js` to easily create a demo administrator account (admin@demo.com / demoadmin123).
- Updates `frontend/index.html` to correctly load the JavaScript files for the Admin Panel components, resolving a React #130 error.