### PR TITLE
fix: Remove duplicate declarations in AdminDashboard

### DIFF
--- a/frontend/scripts/pages/AdminDashboard.js
+++ b/frontend/scripts/pages/AdminDashboard.js
@@ -65,9 +65,8 @@ function AdminDashboard() {
     return <div className="container text-center py-10">No summary data available. (Or still loading initial data)</div>;
   }
 
-  const UserManagement = window.UserManagement;
-  const MerchantManagement = window.MerchantManagement;
-  const PromotionManagement = window.PromotionManagement;
+  // Ensure UserManagement, MerchantManagement, PromotionManagement are available
+  // They are expected to be declared at the top of this function's scope from window object.
 
   const renderCurrentView = () => {
     switch (currentView) {


### PR DESCRIPTION
Removes the erroneous re-declaration of UserManagement, MerchantManagement, and PromotionManagement constants within the AdminDashboard component. These constants are correctly declared at the top of the function scope, and the duplicates caused a SyntaxError: "Identifier has already been declared".