### PR TITLE
feat: Implement initial LoginScreen for mobile app

### DIFF
--- a/mobile_app/lib/main.dart
+++ b/mobile_app/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 // import 'src/screens/deals_list_screen.dart'; // No longer the primary home
-import 'src/screens/home_screen.dart'; // Import the new HomeScreen
+// import 'src/screens/home_screen.dart'; // HomeScreen will be navigated to after login
+import 'src/screens/login_screen.dart'; // Import the LoginScreen
 
 void main() {
   runApp(const MyApp());
@@ -32,21 +33,43 @@ class MyApp extends StatelessWidget {
             borderRadius: BorderRadius.circular(12.0), // More rounded cards
           ),
         ),
-        inputDecorationTheme: InputDecorationTheme( // Theme for TextField on HomeScreen
+        inputDecorationTheme: InputDecorationTheme( // Theme for TextField on HomeScreen and LoginScreen
           filled: true,
-          fillColor: Colors.grey[200],
+          fillColor: Colors.grey[200], // Default fill color for text fields
            border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(25.0),
-            borderSide: BorderSide.none,
+            borderRadius: BorderRadius.circular(10.0), // Standardized border radius
+            borderSide: BorderSide.none, // No border by default for a cleaner look
+          ),
+           enabledBorder: OutlineInputBorder( // Border when enabled but not focused
+            borderRadius: BorderRadius.circular(10.0),
+            borderSide: BorderSide(color: Colors.grey[350]!), // Light grey border
           ),
            focusedBorder: OutlineInputBorder( // Border when TextField is focused
-            borderRadius: BorderRadius.circular(25.0),
+            borderRadius: BorderRadius.circular(10.0),
             borderSide: BorderSide(color: Colors.deepPurple, width: 1.5),
           ),
           hintStyle: TextStyle(color: Colors.grey[600]),
+          // Apply some padding within the text field
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+        ),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.deepPurple, // Button background color
+            foregroundColor: Colors.white, // Button text/icon color
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10.0),
+            ),
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+            textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)
+          ),
+        ),
+        textButtonTheme: TextButtonThemeData(
+          style: TextButton.styleFrom(
+            foregroundColor: Colors.deepPurple, // Text color for TextButtons
+          )
         )
       ),
-      home: const HomeScreen(), // Set HomeScreen as the new home screen
+      home: const LoginScreen(), // Set LoginScreen as the initial screen
     );
   }
 }

--- a/mobile_app/lib/src/screens/login_screen.dart
+++ b/mobile_app/lib/src/screens/login_screen.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../services/api_service.dart';
+import 'home_screen.dart'; // For navigation after login
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final ApiService _apiService = ApiService();
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _login() async {
+    if (_formKey.currentState!.validate()) {
+      setState(() {
+        _isLoading = true;
+        _errorMessage = null;
+      });
+
+      try {
+        final response = await _apiService.loginUser(
+          _emailController.text,
+          _passwordController.text,
+        );
+
+        // Assuming the token is returned in the response map under the key 'token'
+        // And user details are also in the response map.
+        final String? token = response['token'] as String?;
+        // final Map<String, dynamic>? user = response['user'] as Map<String, dynamic>?; // Or however user data is structured
+
+        if (token != null) {
+          // Store the token
+          final prefs = await SharedPreferences.getInstance();
+          await prefs.setString('userToken', token);
+          // Optionally store other user info if needed globally, or manage via a state management solution
+          // await prefs.setString('userName', response['name'] as String? ?? 'User');
+          // await prefs.setString('userEmail', response['email'] as String? ?? '');
+          // await prefs.setString('userRole', response['role'] as String? ?? 'user');
+
+
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Login Successful!'), backgroundColor: Colors.green),
+            );
+            // Navigate to HomeScreen
+            Navigator.of(context).pushReplacement(
+              MaterialPageRoute(builder: (context) => const HomeScreen()),
+            );
+          }
+        } else {
+          throw Exception('Token not found in response');
+        }
+      } catch (e) {
+        if (mounted) {
+          setState(() {
+            _errorMessage = e.toString().replaceFirst('Exception: ', '');
+          });
+        }
+      } finally {
+        if (mounted) {
+          setState(() {
+            _isLoading = false;
+          });
+        }
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Login'),
+        centerTitle: true,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(20.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              const SizedBox(height: 20),
+              Text(
+                'Welcome Back!',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Login to continue your deal hunting.',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(color: Colors.grey[700]),
+              ),
+              const SizedBox(height: 40),
+
+              // Email Field
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(
+                  labelText: 'Email Address',
+                  prefixIcon: Icon(Icons.email_outlined),
+                  border: OutlineInputBorder(),
+                ),
+                keyboardType: TextInputType.emailAddress,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter your email';
+                  }
+                  if (!RegExp(r"^[a-zA-Z0-9.]+@[a-zA-Z0-9]+\.[a-zA-Z]+").hasMatch(value)) {
+                    return 'Please enter a valid email';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 20),
+
+              // Password Field
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(
+                  labelText: 'Password',
+                  prefixIcon: Icon(Icons.lock_outline),
+                  border: OutlineInputBorder(),
+                  // TODO: Add suffix icon for password visibility toggle
+                ),
+                obscureText: true,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter your password';
+                  }
+                  // Optional: Add more password validation rules (length, etc.)
+                  return null;
+                },
+              ),
+              const SizedBox(height: 12),
+
+              // Forgot Password Link
+              Align(
+                alignment: Alignment.centerRight,
+                child: TextButton(
+                  onPressed: () {
+                    // TODO: Navigate to Forgot Password screen
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Forgot Password tapped. (Not implemented yet)')),
+                    );
+                  },
+                  child: const Text('Forgot Password?'),
+                ),
+              ),
+              const SizedBox(height: 25),
+
+              // Login Button
+              _isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 15),
+                        textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                      ),
+                      onPressed: _login,
+                      child: const Text('Login'),
+                    ),
+              const SizedBox(height: 20),
+
+              // Error Message Display
+              if (_errorMessage != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 20.0),
+                  child: Text(
+                    _errorMessage!,
+                    style: TextStyle(color: Theme.of(context).colorScheme.error, fontSize: 14),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+
+              // Register Link
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  const Text("Don't have an account?"),
+                  TextButton(
+                    onPressed: () {
+                      // TODO: Navigate to Register screen
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Register here tapped. (Not implemented yet)')),
+                      );
+                    },
+                    child: const Text('Register here'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 20),
+               // TODO: Add "Login as Demo" button if desired for mobile
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/src/services/api_service.dart
+++ b/mobile_app/lib/src/services/api_service.dart
@@ -1,23 +1,52 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/promotion.dart'; // Placeholder for Promotion model
+// TODO: Potentially create a User model if not already planned
+// import '../models/user.dart';
 
 class ApiService {
   // Using the production Azure URL as discussed.
   static const String _baseUrl = 'https://dealfinder-h0hnh3emahabaahw.southindia-01.azurewebsites.net/api/';
+  // For local development, you might use:
+  // static const String _baseUrl = 'http://10.0.2.2:3001/api/'; // Android emulator
+  // static const String _baseUrl = 'http://localhost:3001/api/'; // iOS simulator/desktop
 
   Future<List<Promotion>> fetchPromotions() async {
     final response = await http.get(Uri.parse('${_baseUrl}promotions'));
 
     if (response.statusCode == 200) {
-      // If the server returns a 200 OK response, parse the JSON.
       List<dynamic> body = jsonDecode(response.body);
       List<Promotion> promotions = body.map((dynamic item) => Promotion.fromJson(item)).toList();
       return promotions;
     } else {
-      // If the server did not return a 200 OK response,
-      // then throw an exception.
-      throw Exception('Failed to load promotions. Status code: ${response.statusCode}');
+      throw Exception('Failed to load promotions. Status code: ${response.statusCode}, Body: ${response.body}');
+    }
+  }
+
+  Future<Map<String, dynamic>> loginUser(String email, String password) async {
+    final response = await http.post(
+      Uri.parse('${_baseUrl}users/login'),
+      headers: <String, String>{
+        'Content-Type': 'application/json; charset=UTF-8',
+      },
+      body: jsonEncode(<String, String>{
+        'email': email,
+        'password': password,
+      }),
+    );
+
+    if (response.statusCode == 200) {
+      // If the server returns a 200 OK response, parse the JSON.
+      // The backend returns the user object and tokens.
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    } else if (response.statusCode == 400 || response.statusCode == 401) {
+      // Specific error for invalid credentials or bad request
+      final errorBody = jsonDecode(response.body);
+      throw Exception(errorBody['message'] ?? 'Invalid email or password.');
+    }
+    else {
+      // For other errors, throw a generic exception.
+      throw Exception('Failed to login. Status code: ${response.statusCode}, Body: ${response.body}');
     }
   }
 }

--- a/mobile_app/pubspec.yaml
+++ b/mobile_app/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   http: ^1.1.0 # For making HTTP requests
   intl: ^0.18.1 # For date formatting
   shimmer: ^3.0.0 # For shimmer loading effect
+  shared_preferences: ^2.2.2 # For storing token
   cupertino_icons: ^1.0.2 # Standard iOS icons
 
 dev_dependencies:


### PR DESCRIPTION
- Create LoginScreen UI with email, password, and login button.
- Implement login logic via ApiService to authenticate.
- Store user token in shared_preferences on success.
- Navigate to HomeScreen post-login.
- Set LoginScreen as initial app route.
- Apply global styling for inputs & buttons.