### PR TITLE
feat: Implement RegisterScreen for mobile app

### DIFF
--- a/mobile_app/lib/src/screens/login_screen.dart
+++ b/mobile_app/lib/src/screens/login_screen.dart
@@ -196,9 +196,8 @@ class _LoginScreenState extends State<LoginScreen> {
                   const Text("Don't have an account?"),
                   TextButton(
                     onPressed: () {
-                      // TODO: Navigate to Register screen
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('Register here tapped. (Not implemented yet)')),
+                      Navigator.of(context).pushReplacement( // Or push, if you want Login to be easily accessible via back button
+                        MaterialPageRoute(builder: (context) => const RegisterScreen()),
                       );
                     },
                     child: const Text('Register here'),

--- a/mobile_app/lib/src/screens/register_screen.dart
+++ b/mobile_app/lib/src/screens/register_screen.dart
@@ -1,0 +1,293 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../services/api_service.dart';
+import 'home_screen.dart'; // For navigation after successful registration
+import 'login_screen.dart'; // For navigation to login
+
+class RegisterScreen extends StatefulWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+enum AccountRole { user, merchant }
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+  final _businessNameController = TextEditingController();
+  final ApiService _apiService = ApiService();
+
+  AccountRole _selectedRole = AccountRole.user;
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    _businessNameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _register() async {
+    if (_formKey.currentState!.validate()) {
+      setState(() {
+        _isLoading = true;
+        _errorMessage = null;
+      });
+
+      Map<String, dynamic> userData = {
+        'name': _nameController.text,
+        'email': _emailController.text,
+        'password': _passwordController.text,
+        'role': _selectedRole.name, // 'user' or 'merchant'
+      };
+
+      if (_selectedRole == AccountRole.merchant) {
+        userData['businessName'] = _businessNameController.text;
+      }
+
+      try {
+        final response = await _apiService.registerUser(userData);
+
+        final String? token = response['token'] as String?;
+        // final Map<String, dynamic>? user = response['user'] as Map<String, dynamic>?; // Or however user data is structured
+
+        if (token != null) {
+          final prefs = await SharedPreferences.getInstance();
+          await prefs.setString('userToken', token);
+          // Optionally store other user info
+
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Registration Successful!'), backgroundColor: Colors.green),
+            );
+            Navigator.of(context).pushAndRemoveUntil(
+              MaterialPageRoute(builder: (context) => const HomeScreen()),
+              (Route<dynamic> route) => false, // Remove all previous routes
+            );
+          }
+        } else {
+          throw Exception('Token not found in registration response');
+        }
+      } catch (e) {
+        if (mounted) {
+          setState(() {
+            _errorMessage = e.toString().replaceFirst('Exception: ', '');
+          });
+        }
+      } finally {
+        if (mounted) {
+          setState(() {
+            _isLoading = false;
+          });
+        }
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Create Account'),
+        centerTitle: true,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(20.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              const SizedBox(height: 10),
+              Text(
+                'Join DealFinder Today!',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 20),
+
+              // Full Name Field
+              TextFormField(
+                controller: _nameController,
+                decoration: const InputDecoration(
+                  labelText: 'Full Name',
+                  prefixIcon: Icon(Icons.person_outline),
+                ),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter your full name';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Email Field
+              TextFormField(
+                controller: _emailController,
+                decoration: const InputDecoration(
+                  labelText: 'Email Address',
+                  prefixIcon: Icon(Icons.email_outlined),
+                ),
+                keyboardType: TextInputType.emailAddress,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter your email';
+                  }
+                  if (!RegExp(r"^[a-zA-Z0-9.]+@[a-zA-Z0-9]+\.[a-zA-Z]+").hasMatch(value)) {
+                    return 'Please enter a valid email';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Password Field
+              TextFormField(
+                controller: _passwordController,
+                decoration: const InputDecoration(
+                  labelText: 'Password',
+                  prefixIcon: Icon(Icons.lock_outline),
+                  // TODO: Add suffix icon for password visibility toggle
+                ),
+                obscureText: true,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please enter a password';
+                  }
+                  if (value.length < 8) {
+                    return 'Password must be at least 8 characters';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Confirm Password Field
+              TextFormField(
+                controller: _confirmPasswordController,
+                decoration: const InputDecoration(
+                  labelText: 'Confirm Password',
+                  prefixIcon: Icon(Icons.lock_reset_outlined),
+                ),
+                obscureText: true,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Please confirm your password';
+                  }
+                  if (value != _passwordController.text) {
+                    return 'Passwords do not match';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 20),
+
+              // Account Type Selection
+              Text('Account Type', style: Theme.of(context).textTheme.titleMedium),
+              Row(
+                children: [
+                  Expanded(
+                    child: RadioListTile<AccountRole>(
+                      title: const Text('User'),
+                      value: AccountRole.user,
+                      groupValue: _selectedRole,
+                      onChanged: (AccountRole? value) {
+                        if (value != null) {
+                          setState(() {
+                            _selectedRole = value;
+                          });
+                        }
+                      },
+                    ),
+                  ),
+                  Expanded(
+                    child: RadioListTile<AccountRole>(
+                      title: const Text('Merchant'),
+                      value: AccountRole.merchant,
+                      groupValue: _selectedRole,
+                      onChanged: (AccountRole? value) {
+                        if (value != null) {
+                          setState(() {
+                            _selectedRole = value;
+                          });
+                        }
+                      },
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 10),
+
+              // Business Name Field (Conditional)
+              if (_selectedRole == AccountRole.merchant)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 16.0),
+                  child: TextFormField(
+                    controller: _businessNameController,
+                    decoration: const InputDecoration(
+                      labelText: 'Business Name',
+                      prefixIcon: Icon(Icons.store_mall_directory_outlined),
+                    ),
+                    validator: (value) {
+                      if (_selectedRole == AccountRole.merchant && (value == null || value.isEmpty)) {
+                        return 'Please enter your business name';
+                      }
+                      return null;
+                    },
+                  ),
+                ),
+
+              // Error Message Display
+              if (_errorMessage != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0, bottom: 8.0),
+                  child: Text(
+                    _errorMessage!,
+                    style: TextStyle(color: Theme.of(context).colorScheme.error, fontSize: 14),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              const SizedBox(height: 10),
+
+              // Register Button
+              _isLoading
+                  ? const Center(child: CircularProgressIndicator())
+                  : ElevatedButton(
+                      onPressed: _register,
+                      child: const Text('Sign Up'),
+                    ),
+              const SizedBox(height: 16),
+
+              // Login Link
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  const Text("Already have an account?"),
+                  TextButton(
+                    onPressed: () {
+                      Navigator.of(context).pushReplacement(
+                        MaterialPageRoute(builder: (context) => const LoginScreen()),
+                      );
+                    },
+                    child: const Text('Log In'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 20),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_app/lib/src/services/api_service.dart
+++ b/mobile_app/lib/src/services/api_service.dart
@@ -50,4 +50,29 @@ class ApiService {
       throw Exception('Failed to login. Status code: ${response.statusCode}, Body: ${response.body}');
     }
   }
+
+  Future<Map<String, dynamic>> registerUser(Map<String, dynamic> userData) async {
+    final response = await http.post(
+      Uri.parse('${_baseUrl}users/register'),
+      headers: <String, String>{
+        'Content-Type': 'application/json; charset=UTF-8',
+      },
+      body: jsonEncode(userData),
+    );
+
+    if (response.statusCode == 201) { // Registration successful
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    } else if (response.statusCode == 400) { // Bad request (e.g., validation errors, email exists)
+      final errorBody = jsonDecode(response.body);
+      // Backend might return specific error messages or an array of errors
+      if (errorBody['errors'] != null && errorBody['errors'] is List) {
+        // Join multiple validation errors if present
+        String messages = (errorBody['errors'] as List).map((e) => e['msg']).join(', ');
+        throw Exception(messages.isNotEmpty ? messages : 'Registration failed. Please check your input.');
+      }
+      throw Exception(errorBody['message'] ?? 'Registration failed. Please check your input.');
+    } else {
+      throw Exception('Registration failed. Status code: ${response.statusCode}, Body: ${response.body}');
+    }
+  }
 }


### PR DESCRIPTION
- Add RegisterScreen with fields for name, email, password, role (user/merchant), and conditional business name.
- Implement form validation for all registration fields.
- Update ApiService with a `registerUser` method.
- RegisterScreen now calls the API, handles success (stores token, navigates to HomeScreen), and displays errors.
- Add navigation between LoginScreen and RegisterScreen.