### PR TITLE
feat: Implement User Profile screen with logout

### DIFF
--- a/mobile_app/lib/src/screens/home_screen.dart
+++ b/mobile_app/lib/src/screens/home_screen.dart
@@ -7,6 +7,7 @@ import '../services/api_service.dart'; // Import the API service
 import '../widgets/deal_card.dart'; // Import the DealCard widget
 import 'deal_detail_screen.dart'; // Import DealDetailScreen for navigation
 import 'deals_list_screen.dart'; // Import DealsListScreen for "View All"
+import 'user_profile_screen.dart'; // Import UserProfileScreen
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -42,16 +43,25 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('DealFinder'), // Or a logo
-        // actions: [ // Potential actions like notifications or profile
-        //   IconButton(
-        //     icon: const Icon(Icons.notifications_none),
-        //     onPressed: () {},
-        //   ),
-        //   IconButton(
-        //     icon: const Icon(Icons.account_circle),
-        //     onPressed: () {},
-        //   ),
-        // ],
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.account_circle_outlined),
+            tooltip: 'Profile',
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (context) => const UserProfileScreen()),
+              );
+            },
+          ),
+          // Potential other actions like notifications
+          // IconButton(
+          //   icon: const Icon(Icons.notifications_none_outlined),
+          //   tooltip: 'Notifications',
+          //   onPressed: () {
+          //     // TODO: Navigate to Notifications Screen
+          //   },
+          // ),
+        ],
       ),
       body: CustomScrollView(
         slivers: <Widget>[

--- a/mobile_app/lib/src/screens/login_screen.dart
+++ b/mobile_app/lib/src/screens/login_screen.dart
@@ -47,11 +47,17 @@ class _LoginScreenState extends State<LoginScreen> {
           // Store the token
           final prefs = await SharedPreferences.getInstance();
           await prefs.setString('userToken', token);
-          // Optionally store other user info if needed globally, or manage via a state management solution
-          // await prefs.setString('userName', response['name'] as String? ?? 'User');
-          // await prefs.setString('userEmail', response['email'] as String? ?? '');
-          // await prefs.setString('userRole', response['role'] as String? ?? 'user');
 
+          // Store additional user details
+          await prefs.setString('userName', response['name'] as String? ?? 'N/A');
+          await prefs.setString('userEmail', response['email'] as String? ?? 'N/A');
+          final userRole = response['role'] as String? ?? 'user';
+          await prefs.setString('userRole', userRole);
+          if (userRole == 'merchant' && response['businessName'] != null) {
+            await prefs.setString('userBusinessName', response['businessName'] as String);
+          } else {
+            await prefs.remove('userBusinessName'); // Ensure it's clear if not a merchant or no business name
+          }
 
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(

--- a/mobile_app/lib/src/screens/register_screen.dart
+++ b/mobile_app/lib/src/screens/register_screen.dart
@@ -63,7 +63,18 @@ class _RegisterScreenState extends State<RegisterScreen> {
         if (token != null) {
           final prefs = await SharedPreferences.getInstance();
           await prefs.setString('userToken', token);
-          // Optionally store other user info
+
+          // Store additional user details from the registration response
+          // Assuming the registration response structure is similar to login for these fields
+          await prefs.setString('userName', response['name'] as String? ?? 'N/A');
+          await prefs.setString('userEmail', response['email'] as String? ?? 'N/A');
+          final userRole = response['role'] as String? ?? 'user';
+          await prefs.setString('userRole', userRole);
+          if (userRole == 'merchant' && response['businessName'] != null) {
+            await prefs.setString('userBusinessName', response['businessName'] as String);
+          } else {
+             await prefs.remove('userBusinessName');
+          }
 
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(

--- a/mobile_app/lib/src/screens/user_profile_screen.dart
+++ b/mobile_app/lib/src/screens/user_profile_screen.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'login_screen.dart'; // For logout navigation
+
+class UserProfileScreen extends StatefulWidget {
+  const UserProfileScreen({super.key});
+
+  @override
+  State<UserProfileScreen> createState() => _UserProfileScreenState();
+}
+
+class _UserProfileScreenState extends State<UserProfileScreen> {
+  String _name = 'Loading...';
+  String _email = 'Loading...';
+  String _role = 'Loading...';
+  String? _businessName;
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadUserData();
+  }
+
+  Future<void> _loadUserData() async {
+    setState(() {
+      _isLoading = true;
+    });
+    final prefs = await SharedPreferences.getInstance();
+    _name = prefs.getString('userName') ?? 'N/A';
+    _email = prefs.getString('userEmail') ?? 'N/A';
+    _role = prefs.getString('userRole') ?? 'user'; // Default to 'user' if not found
+    if (_role == 'merchant') {
+      _businessName = prefs.getString('userBusinessName');
+    }
+    setState(() {
+      _isLoading = false;
+    });
+  }
+
+  Future<void> _logout() async {
+    // Logout logic will be fully implemented in the next step
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('userToken');
+    await prefs.remove('userName');
+    await prefs.remove('userEmail');
+    await prefs.remove('userRole');
+    await prefs.remove('userBusinessName');
+
+    if (mounted) {
+      Navigator.of(context).pushAndRemoveUntil(
+        MaterialPageRoute(builder: (context) => const LoginScreen()),
+        (Route<dynamic> route) => false,
+      );
+    }
+  }
+
+  Widget _buildInfoRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('$label: ', style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+          Expanded(child: Text(value, style: const TextStyle(fontSize: 16))),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('User Profile'),
+        centerTitle: true,
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(
+              onRefresh: _loadUserData, // Allows pull-to-refresh user data
+              child: ListView(
+                padding: const EdgeInsets.all(20.0),
+                children: <Widget>[
+                  // User Avatar (Placeholder)
+                  CircleAvatar(
+                    radius: 50,
+                    backgroundColor: Colors.grey[300],
+                    child: Icon(
+                      _role == 'merchant' ? Icons.store_mall_directory : Icons.person,
+                      size: 50,
+                      color: Colors.grey[700],
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  _buildInfoRow('Name', _name),
+                  _buildInfoRow('Email', _email),
+                  _buildInfoRow('Role', _role.capitalize()),
+                  if (_role == 'merchant' && _businessName != null && _businessName!.isNotEmpty)
+                    _buildInfoRow('Business Name', _businessName!),
+
+                  const SizedBox(height: 30),
+                  ElevatedButton(
+                    onPressed: () {
+                      // Placeholder for Edit Profile functionality
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Edit Profile tapped (Not implemented yet).')),
+                      );
+                    },
+                    child: const Text('Edit Profile'),
+                  ),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: _logout, // Placeholder, will be implemented next
+                    style: ElevatedButton.styleFrom(backgroundColor: Colors.red[400]),
+                    child: const Text('Logout'),
+                  ),
+                ],
+              ),
+            ),
+    );
+  }
+}
+
+// Helper extension to capitalize strings
+extension StringExtension on String {
+    String capitalize() {
+      if (isEmpty) return this;
+      return "${this[0].toUpperCase()}${substring(1).toLowerCase()}";
+    }
+}


### PR DESCRIPTION
- Update LoginScreen and RegisterScreen to store user details (name, email, role, businessName) in shared_preferences.
- Create UserProfileScreen to display these details.
- Implement logout functionality on UserProfileScreen, clearing shared_preferences and navigating to LoginScreen.
- Add navigation to UserProfileScreen from HomeScreen AppBar.
- Include pull-to-refresh on UserProfileScreen.