### PR TITLE
feat: Rename 'Nearby Deals' to 'Latest Deals' on HomeScreen

### DIFF
--- a/mobile_app/lib/src/screens/home_screen.dart
+++ b/mobile_app/lib/src/screens/home_screen.dart
@@ -254,7 +254,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
                   Text(
-                    'Nearby Deals',
+                    'Latest Deals', // Renamed from 'Nearby Deals'
                      style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
                   ),
                   TextButton(


### PR DESCRIPTION
- Updated the section title from 'Nearby Deals' to 'Latest Deals'.
- Verified that the existing logic correctly displays up to 10 deals in this section, following the 10 'Featured Deals'.