### PR TITLE
Fix: Enforce JWT secrets via environment variables

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -6,7 +6,11 @@ function authenticateJWT(req, res, next) {
   const authHeader = req.headers.authorization;
   if (authHeader && authHeader.startsWith('Bearer ')) {
     const token = authHeader.split(' ')[1];
-    jwt.verify(token, process.env.JWT_SECRET || 'your_jwt_secret', (err, user) => {
+    if (!process.env.JWT_SECRET) {
+      console.error('CRITICAL: JWT_SECRET is not defined in environment variables.');
+      return res.status(500).json({ message: 'Server configuration error.' });
+    }
+    jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
       if (err) {
         // console.error("JWT Verification Error:", err.message);
         return res.status(403).json({ message: 'Invalid or expired token' });
@@ -69,7 +73,10 @@ function gentleAuthenticateJWT(req, res, next) {
   const authHeader = req.headers.authorization;
   if (authHeader && authHeader.startsWith('Bearer ')) {
     const token = authHeader.split(' ')[1];
-    jwt.verify(token, process.env.JWT_SECRET || 'your_jwt_secret', (err, user) => {
+    // No need to check JWT_SECRET here again if authenticateJWT already does,
+    // but gentle one might be called independently. For safety, keep a check or ensure server exits if not set.
+    // For now, assuming server startup check will handle this.
+    jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
       if (!err) {
         req.user = user;
       } // If error, just proceed without req.user

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -16,7 +16,7 @@ function generateToken(user) {
   return jwt.sign(
     // Ensure merchantId is included in the token if the user is a merchant
     { id: user._id, email: user.email, role: user.role, merchantId: user.merchantId },
-    process.env.JWT_SECRET || 'your_jwt_secret',
+    process.env.JWT_SECRET, // Relies on server startup check for presence
     { expiresIn: '7d' }
   );
 }
@@ -26,7 +26,7 @@ function generateRefreshToken(user) {
   return jwt.sign(
     // Ensure merchantId is included in the token if the user is a merchant
     { id: user._id, email: user.email, role: user.role, merchantId: user.merchantId },
-    process.env.JWT_REFRESH_SECRET || 'your_jwt_refresh_secret',
+    process.env.JWT_REFRESH_SECRET, // Relies on server startup check for presence
     { expiresIn: '30d' }
   );
 }
@@ -177,7 +177,8 @@ router.post('/refresh-token', (req, res) => {
   if (!refreshToken || !refreshTokens.has(refreshToken)) {
     return res.status(401).json({ message: 'Invalid refresh token' });
   }
-  jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET || 'your_jwt_refresh_secret', (err, user) => {
+  // generateToken and generateRefreshToken will now rely on server checks for JWT_SECRET and JWT_REFRESH_SECRET
+  jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET, (err, user) => {
     if (err) return res.status(403).json({ message: 'Invalid or expired refresh token' });
     const newToken = generateToken(user);
     res.status(200).json({ token: newToken });

--- a/backend/server.js
+++ b/backend/server.js
@@ -112,21 +112,25 @@ app.use((err, req, res, next) => {
   });
 });
 
-// Ensure JWT_SECRET is set
+// Ensure critical JWT secrets are set
 if (!process.env.JWT_SECRET) {
-  console.warn('Warning: JWT_SECRET is not set in environment variables. Using default (insecure) secret.');
-  console.warn('To fix: Set JWT_SECRET in a .env file at backend/.env or in your environment variables.');
+  console.error('CRITICAL ERROR: JWT_SECRET is not defined in environment variables.');
+  console.error('The application cannot start without a JWT_SECRET.');
+  console.error('Please set JWT_SECRET in your environment (e.g., .env file or hosting provider configuration).');
+  process.exit(1); // Exit the process with an error code
 }
 
-// Ensure JWT_REFRESH_SECRET is set
 if (!process.env.JWT_REFRESH_SECRET) {
-  console.warn('Warning: JWT_REFRESH_SECRET is not set in environment variables. Using default (insecure) secret.');
-  console.warn('To fix: Set JWT_REFRESH_SECRET in a .env file at backend/.env or in your environment variables.');
+  console.error('CRITICAL ERROR: JWT_REFRESH_SECRET is not defined in environment variables.');
+  console.error('The application cannot start without a JWT_REFRESH_SECRET.');
+  console.error('Please set JWT_REFRESH_SECRET in your environment (e.g., .env file or hosting provider configuration).');
+  process.exit(1); // Exit the process with an error code
 }
 
 // Start Server
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);
+  console.log('JWT_SECRET and JWT_REFRESH_SECRET environment variables are loaded.'); // Confirmation that checks passed
 });
 
 module.exports = mongoose;


### PR DESCRIPTION
- Removed default fallback JWT secrets in middleware and user routes.
- Added server startup checks to ensure JWT_SECRET and JWT_REFRESH_SECRET are defined.
- Application will exit if secrets are not found in env variables.