### PR TITLE
Fix: Ensure header updates immediately on login/logout

### DIFF
--- a/frontend/scripts/components/UserMenu.js
+++ b/frontend/scripts/components/UserMenu.js
@@ -8,11 +8,30 @@ function UserMenu() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // Check if user is logged in
-    const userData = localStorage.getItem('dealFinderUser');
-    if (userData) {
-      setUser(JSON.parse(userData));
-    }
+    // Function to update user state from localStorage
+    const updateUserState = () => {
+      const userData = localStorage.getItem('dealFinderUser');
+      if (userData) {
+        try {
+          setUser(JSON.parse(userData));
+        } catch (e) {
+          console.error("Failed to parse user data from localStorage", e);
+          localStorage.removeItem('dealFinderUser'); // Clear corrupted data
+          setUser(null);
+        }
+      } else {
+        setUser(null);
+      }
+    };
+
+    // Initial check
+    updateUserState();
+
+    // Listen for auth state changes
+    const handleAuthStateChange = () => {
+      updateUserState();
+    };
+    window.addEventListener('authStateChange', handleAuthStateChange);
 
     // Close menu when clicking outside
     const handleClickOutside = (event) => {
@@ -20,10 +39,12 @@ function UserMenu() {
         setIsMenuOpen(false);
       }
     };
-
     document.addEventListener('mousedown', handleClickOutside);
+
+    // Cleanup
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
+      window.removeEventListener('authStateChange', handleAuthStateChange);
     };
   }, []);
 

--- a/frontend/scripts/utils/authHelpers.js
+++ b/frontend/scripts/utils/authHelpers.js
@@ -33,11 +33,13 @@ function isAdmin() {
 // Login user (store in localStorage)
 function loginUser(userData) {
   localStorage.setItem('dealFinderUser', JSON.stringify(userData));
+  window.dispatchEvent(new CustomEvent('authStateChange'));
 }
 
 // Logout user
 function logoutUser() {
   localStorage.removeItem('dealFinderUser');
+  window.dispatchEvent(new CustomEvent('authStateChange'));
 }
 
 // Register and login


### PR DESCRIPTION
- Dispatched 'authStateChange' custom event from authHelpers on login/logout.
- UserMenu now listens for 'authStateChange' event to refresh user state from localStorage and re-render.