### PR TITLE
Fix: Resolve 400 Bad Request on promotion creation

### DIFF
--- a/backend/routes/promotionRoutes.js
+++ b/backend/routes/promotionRoutes.js
@@ -100,9 +100,9 @@ router.get('/merchant/:merchantId', async (req, res) => {
 // Create a new promotion (Authenticated: Admin, or Merchant for themselves)
 router.post('/', authenticateJWT, [
   body('title').trim().notEmpty().withMessage('Title is required'),
-  body('description').optional().isString(),
+  body('description').trim().notEmpty().withMessage('Description is required'),
   body('discount').trim().notEmpty().withMessage('Discount is required'),
-  body('code').optional().isString(),
+  body('code').trim().notEmpty().withMessage('Promotion code is required'),
   body('category').trim().notEmpty().withMessage('Category is required'),
   body('startDate').isISO8601().withMessage('Start date must be a valid date'),
   body('endDate').isISO8601().withMessage('End date must be a valid date'),

--- a/frontend/scripts/pages/MerchantDashboard.js
+++ b/frontend/scripts/pages/MerchantDashboard.js
@@ -219,12 +219,19 @@ function MerchantDashboard() {
       return;
     }
 
+    // Ensure merchantId is present before attempting to save
+    if (!user || !user.merchantId) {
+      console.error('Error saving promotion: merchantId is missing from user object.', user);
+      alert('Cannot save promotion: Your merchant account is not properly configured. Please re-login or contact support.');
+      return;
+    }
+
     try {
       // Ensure featured is a boolean
       const promotionData = {
         ...formData,
         featured: Boolean(formData.featured), // Force boolean
-        merchantId: user.merchantId
+        merchantId: user.merchantId // Now we know user.merchantId exists
       };
 
       let savedPromotion;


### PR DESCRIPTION
- Added a frontend check in MerchantDashboard.js to ensure `user.merchantId` is present before attempting to create/update a promotion. If missing, an alert is shown to the user, and the API call is prevented.
- Aligned backend express-validator rules in `promotionRoutes.js` for `description` and `code` fields to be `notEmpty()`, matching the Promotion model's schema requirements. This prevents potential 500 errors if these fields were omitted by the client, making backend validation more robust.