### PR TITLE
Fix: Correct potential JSX syntax error in UserProfile.js

### DIFF
--- a/frontend/scripts/pages/UserProfile.js
+++ b/frontend/scripts/pages/UserProfile.js
@@ -829,7 +829,7 @@ function UserProfile() {
                         rows="3"
                       ></textarea>
                     </div>
-                     <div className="mb-4">
+                    <div className="mb-4">
                         <label htmlFor="initLogo" className="block text-sm font-medium mb-1">Business Logo URL (Optional)</label>
                         <input
                             type="url"


### PR DESCRIPTION
- Addressed a 'Unexpected token, expected ","' error reported by Babel.
- The fix involved removing a potential extraneous leading space before a <div> tag within the merchant profile initialization form's JSX structure.
- This aims to ensure correct parsing and rendering of the UserProfile component, particularly the new merchant initialization UI.