### PR TITLE
Submit UserProfile.js with Normal Profile Form commented out for debug

### DIFF
--- a/frontend/scripts/pages/UserProfile.js
+++ b/frontend/scripts/pages/UserProfile.js
@@ -478,7 +478,7 @@ function UserProfile() {
                 </div>
               )}
               
-              {/* Profile Settings */}
+              {/* Profile Settings - Temporarily Commented Out for Debugging Syntax Error
               {activeTab === 'profile' && !showMerchantInitForm && (
               <div>
                   <h1 className="text-2xl font-bold mb-6">Profile Settings</h1>
@@ -795,6 +795,7 @@ function UserProfile() {
                   </form>
                 </div>
               )}
+              */}
 
               {/* Merchant Initialization Form */}
               {showMerchantInitForm && activeTab === 'profile' &&


### PR DESCRIPTION
Code for UserProfile.js is being submitted in its current state per explicit user directive, despite an unresolved syntax error (`Unexpected token, expected "}"` or similar) that likely breaks the UserProfile page.

This commit captures the state where the 'Normal Profile Settings Form' JSX block was commented out in an attempt to isolate the syntax error. The 'Merchant Initialization Form' (with its optional fields also commented out) remains part of the active code being debugged.