### PR TITLE
fix: Correct import of gentleAuthenticateJWT in userRoutes

### DIFF
--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -6,7 +6,8 @@ const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const crypto = require('crypto');
 const { body, validationResult } = require('express-validator');
-const { authenticateJWT, authorizeAdmin, authorizeSelfOrAdmin } = require('../middleware/auth');
+// Import gentleAuthenticateJWT
+const { authenticateJWT, authorizeAdmin, authorizeSelfOrAdmin, gentleAuthenticateJWT } = require('../middleware/auth');
 
 // In-memory store for refresh tokens
 const refreshTokens = new Set();


### PR DESCRIPTION
Resolves a ReferenceError that caused the server to crash on startup. The gentleAuthenticateJWT middleware was not correctly destructured during import in backend/routes/userRoutes.js.

This fix addresses the immediate cause of the 500 Internal Server Error reported by Azure logs.