### PR TITLE
fix: Refine state update for location inputs in MerchantDashboard

### DIFF
--- a/frontend/scripts/pages/MerchantDashboard.js
+++ b/frontend/scripts/pages/MerchantDashboard.js
@@ -422,13 +422,15 @@ function MerchantDashboard() {
       }));
     } else if (name === "latitude" || name === "longitude") {
       const coordIndex = name === "longitude" ? 0 : 1;
-      const newCoordinates = [...prev.location.coordinates];
-      // Allow empty string to clear the field, parse to float if not empty
-      newCoordinates[coordIndex] = value === '' ? null : parseFloat(value);
-      setProfileFormData(prev => ({
-        ...prev,
+      const newCoordinates = [...profileFormData.location.coordinates]; // Use current state, not prev from updater
+      const stringValue = String(value); // Ensure value is a string before parsing
+
+      newCoordinates[coordIndex] = stringValue === '' ? null : parseFloat(stringValue);
+
+      setProfileFormData(currentFormData => ({ // Use functional update form
+        ...currentFormData,
         location: {
-          ...prev.location,
+          ...currentFormData.location,
           coordinates: newCoordinates
         }
       }));


### PR DESCRIPTION
- Adjusted the way latitude and longitude state is updated in `handleProfileInputChange` within `MerchantDashboard.js` to ensure robustness.
- This is in response to an issue where input fields were reportedly not accepting data. Further debugging may be needed if the issue persists, likely by checking browser console errors.

Previous feature work includes:
- Add latitude/longitude to Merchant model and enable manual input in the merchant dashboard.
- Create backend API endpoint (/api/promotions/nearby) to fetch promotions based on geographic proximity using GeoJSON and $geoNear.
- Integrate browser geolocation on the web homepage to request user's location.
- Display nearby deals on the homepage, including distance to the merchant, with loading and error states.