### PR TITLE
Fix: Correct auth middleware for user registration endpoint

### DIFF
--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -35,7 +35,7 @@ function generateRefreshToken(user) {
 // Middleware to protect routes
 function protectRoute(req, res, next) {
   const openRoutes = [
-    // { path: '/register', method: 'POST' }, // Will be handled by gentleAuthenticateJWT
+    { path: '/register', method: 'POST' }, // Will be handled by gentleAuthenticateJWT
     { path: '/login', method: 'POST' },
     { path: '/refresh-token', method: 'POST' },
     { path: '/reset-password', method: 'POST' },


### PR DESCRIPTION
Uncomments the /register route from the protectRoute middleware's list of open routes in userRoutes.js.

This ensures that the strict authenticateJWT middleware is not applied to the registration endpoint, resolving the 401 Unauthorized error for new users attempting to register. The route's own gentleAuthenticateJWT correctly handles optional authentication for this path.