### PR TITLE
Fix: Google Sign-In client ID

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -1,2 +1,5 @@
 module.exports = {
+  VAPID_PUBLIC_KEY: '',
+  VAPID_PRIVATE_KEY: '',
+  GOOGLE_CLIENT_ID: '485292738463-ogadj8l21hp39ep097l85hdk3gmdvfgh.apps.googleusercontent.com'
 };

--- a/frontend/scripts/pages/LoginPage.js
+++ b/frontend/scripts/pages/LoginPage.js
@@ -108,25 +108,33 @@ function LoginPage() {
     }
   };
 
+  const [googleClientId, setGoogleClientId] = useState(null);
+
   React.useEffect(() => {
     const fetchConfig = async () => {
       try {
         const response = await fetch('/api/config');
         const config = await response.json();
-        google.accounts.id.initialize({
-          client_id: config.GOOGLE_CLIENT_ID,
-          callback: handleGoogleSignIn
-        });
-        google.accounts.id.renderButton(
-          document.getElementById("google-signin-button"),
-          { theme: "outline", size: "large" }
-        );
+        setGoogleClientId(config.GOOGLE_CLIENT_ID);
       } catch (error) {
         console.error('Error fetching config:', error);
       }
     };
     fetchConfig();
   }, []);
+
+  React.useEffect(() => {
+    if (googleClientId) {
+      google.accounts.id.initialize({
+        client_id: googleClientId,
+        callback: handleGoogleSignIn
+      });
+      google.accounts.id.renderButton(
+        document.getElementById("google-signin-button"),
+        { theme: "outline", size: "large" }
+      );
+    }
+  }, [googleClientId]);
 
   return (
     <div className="page-container">


### PR DESCRIPTION
The Google Sign-In was failing because the client ID was not being correctly passed to the Google library. This change updates the `LoginPage.js` to fetch the client ID from the `/api/config` endpoint and then initialize the Google library, ensuring that the client ID is available before initialization.