### PR TITLE
Fix: Google Sign-In JWT secret

### DIFF
--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -492,7 +492,7 @@ router.post('/google-signin', async (req, res) => {
         let user = await User.findOne({ email });
         if (!user) {
             // Create a new user if they don't exist
-            const password = email + config.JWT_SECRET;
+            const password = email + process.env.JWT_SECRET;
             const hashedPassword = await bcrypt.hash(password, 10);
             user = new User({
                 name,


### PR DESCRIPTION
The Google Sign-In route was using `config.JWT_SECRET` instead of `process.env.JWT_SECRET`, which was causing a 500 Internal Server Error. This change updates the route to use the correct JWT secret.