### PR TITLE
Fix: Remove bcryptjs dependency

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^6.0.0",
-        "bcryptjs": "^3.0.2",
         "body-parser": "^1.20.2",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
@@ -161,15 +160,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/bcryptjs": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
-      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
-      "license": "BSD-3-Clause",
-      "bin": {
-        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/bignumber.js": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "bcrypt": "^6.0.0",
-    "bcryptjs": "^3.0.2",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
This change removes the `bcryptjs` dependency to resolve conflicts with `bcrypt`.