### PR TITLE
Fix(server): Serve frontend directory

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -88,6 +88,7 @@ adminRouter.use('/', adminDashboardRoutes); // Mounted at /api/admin/dashboard/s
 app.use('/api/admin', adminRouter);
 
 // Serve static files - IMPORTANT: These must come BEFORE the catch-all routes
+app.use(express.static(path.join(__dirname, '../frontend')));
 app.use('/backend/public/libs', express.static(path.join(__dirname, 'public/libs')));
 app.use('/scripts', express.static(path.join(__dirname, '../frontend/scripts')));
 app.use('/styles', express.static(path.join(__dirname, '../frontend/styles')));


### PR DESCRIPTION
This commit fixes a 404 error for the `firebase-messaging-sw.js` file. The browser was unable to register the service worker because the file was not being served correctly.

This commit introduces the following changes:

- Adds `app.use(express.static(path.join(__dirname, '../frontend')));` to `backend/server.js`. This serves the entire `frontend` directory, making the service worker and other static files accessible to the browser.